### PR TITLE
Fix Timezones for non-USE_TZ Django Instances.

### DIFF
--- a/django_celery_beat/utils.py
+++ b/django_celery_beat/utils.py
@@ -21,6 +21,21 @@ def make_aware(value):
         # then convert to the Django configured timezone.
         default_tz = timezone.get_default_timezone()
         value = timezone.localtime(value, default_tz)
+    else:
+        # naive datetimes should be in Django's timezone.
+        if timezone.is_naive(value):
+            default_tz = timezone.get_default_timezone()
+            value = timezone.make_aware(value, default_tz)
+    return value
+
+
+def maybe_make_unaware(value):
+    """Remove tz if not configured."""
+    if not getattr(settings, 'USE_TZ', False) and timezone.is_aware(value):
+        # Convert to Django's configured timezone and then remove the timezone.
+        default_tz = timezone.get_default_timezone()
+        value = timezone.localtime(value, default_tz)
+        value = value.replace(tzinfo=None)
     return value
 
 


### PR DESCRIPTION
1) Use Celery app.now for celery.beat schedulers.
2) Strip TZ from last_run_time on save if non USE_TZ instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/myvr/django-celery-beat/1)
<!-- Reviewable:end -->
